### PR TITLE
update to msal 4.45.0

### DIFF
--- a/iwa-console/iwa-console.csproj
+++ b/iwa-console/iwa-console.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- update to msal 4.45.0
- Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of StackOverFlow exception (SOE) whenever nested expressions are being processed.

## Purpose
Version update and others

## Does this introduce a breaking change?
No


## Pull Request Type
Other... Please describe: sample update 

## How to Test
*  Get the code
